### PR TITLE
Fix HTML links to ai-slop-blog.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
             <section id="posts">
                 <h2>Blog Posts</h2>
                 <article>
-                    <h3><a href="blog/2024-07-26-ai-slop/ai-slop.html">AI Slop: Navigating the Era of Artificial Intelligence</a></h3>
+                    <h3><a href="ai-slop-blog.html">AI Slop: Navigating the Era of Artificial Intelligence</a></h3>
                     <time datetime="2024-07-26">July 26, 2024</time>
                     <p>Read my latest thoughts on the current state of artificial intelligence and content creation.</p>
                 </article>


### PR DESCRIPTION
## Summary
- Updated link in index.html to point to ai-slop-blog.html instead of non-existent blog/2024-07-26-ai-slop/ai-slop.html path
- Verified all HTML links in the website are correctly configured

## Test plan
- [ ] Test that clicking on the blog post link in index.html takes users to the ai-slop-blog.html page
- [ ] Verify that navigation from more.html to index.html works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)